### PR TITLE
Fix bug with $sourceConnection variable

### DIFF
--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -130,7 +130,7 @@ function Copy-DbaSsisCatalog {
                 [String]$Folder
             )
             $sqlConn = New-Object System.Data.SqlClient.SqlConnection
-            $sqlConn.ConnectionString = $sourceConnection.ConnectionContext.ConnectionString
+            $sqlConn.ConnectionString = $sourceServer.ConnectionContext.ConnectionString
             if ($sqlConn.State -eq "Closed") {
                 $sqlConn.Open()
             }
@@ -253,10 +253,10 @@ function Copy-DbaSsisCatalog {
         }
 
         try {
-            $sourceSSIS = New-Object "$ISNamespace.IntegrationServices" $sourceConnection
+            $sourceSSIS = New-Object "$ISNamespace.IntegrationServices" $sourceServer
         }
         catch {
-            Stop-Function -Message "There was an error connecting to the source integration services." -Target $sourceConnection -ErrorRecord $_
+            Stop-Function -Message "There was an error connecting to the source integration services." -Target $sourceServer -ErrorRecord $_
             return
         }
 


### PR DESCRIPTION
The $sourceConnection variable was being used in three places but never being set. Actual variable is called $sourceServer. Entire module wasn't working before this fix, but works now.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4157)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
